### PR TITLE
feat(zone): expose relay_on property

### DIFF
--- a/pytouchlinesl/zone.py
+++ b/pytouchlinesl/zone.py
@@ -112,6 +112,11 @@ class Zone:
 
         return self._schedule
 
+    @property
+    def relay_on(self) -> bool:
+        """Return whether or not the zone's relay is on."""
+        return self._raw_data.zone.flags.relay_state == "on"
+
     async def set_temperature(self, temperature: float):
         """Set a constant target temperature for the zone."""
         await self._client.set_zone_temperature(

--- a/tests/sample-data/module.json
+++ b/tests/sample-data/module.json
@@ -268,7 +268,7 @@
           "currentTemperature": 221,
           "setTemperature": 180,
           "flags": {
-            "relayState": "off",
+            "relayState": "on",
             "minOneWindowOpen": false,
             "algorithm": "heating",
             "floorSensor": 0,

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -6,6 +6,7 @@ test_attrs = [
     ("humidity", 61.0),
     ("mode", "globalSchedule"),
     ("enabled", True),
+    ("relay_on", True),
 ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -404,7 +404,7 @@ wheels = [
 
 [[package]]
 name = "pytouchlinesl"
-version = "0.1.2"
+version = "0.1.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Thanks for creating this integration! I've been thinking about doing it myself for a while, but never got around to it.

The one thing I missed is the relay state which shows which zones are actively being heated. This shows up as a pulsing indicator in the Roth app, and a blinking icon on the thermostat. This PR should cover it.

This state could be used to toggle the `hvac_mode` in Home Assistant, so it's not locked to `Heat`, but open to suggestions on that one since I'm unfamiliar with the inner workings of Home Assistant.