### PR TITLE
fix: add missing field types for `zone_state`

### DIFF
--- a/pytouchlinesl/client/models/models.py
+++ b/pytouchlinesl/client/models/models.py
@@ -31,7 +31,7 @@ class ZoneAttributesModel(BaseModel):
     set_temperature: int = Field(..., alias="setTemperature")
     flags: ZoneFlagsModel
     zone_state: Literal[
-        "zoneOff", "zoneOn", "noAlarm", "zoneUnregistered", "sensorDamaged", "noCommunication"
+        "zoneOff", "noAlarm", "zoneUnregistered", "sensorDamaged", "noCommunication"
     ] = Field(..., alias="zoneState")
     signal_strength: Optional[int] = Field(..., alias="signalStrength")
     battery_level: Optional[int] = Field(..., alias="batteryLevel")

--- a/pytouchlinesl/client/models/models.py
+++ b/pytouchlinesl/client/models/models.py
@@ -30,7 +30,9 @@ class ZoneAttributesModel(BaseModel):
     current_temperature: Optional[int] = Field(..., alias="currentTemperature")
     set_temperature: int = Field(..., alias="setTemperature")
     flags: ZoneFlagsModel
-    zone_state: Literal["zoneOff", "zoneOn", "noAlarm", "zoneUnregistered", "sensorDamaged", "noCommunication"] = Field(..., alias="zoneState")
+    zone_state: Literal[
+        "zoneOff", "zoneOn", "noAlarm", "zoneUnregistered", "sensorDamaged", "noCommunication"
+    ] = Field(..., alias="zoneState")
     signal_strength: Optional[int] = Field(..., alias="signalStrength")
     battery_level: Optional[int] = Field(..., alias="batteryLevel")
     actuators_open: int = Field(..., alias="actuatorsOpen")

--- a/pytouchlinesl/client/models/models.py
+++ b/pytouchlinesl/client/models/models.py
@@ -30,7 +30,7 @@ class ZoneAttributesModel(BaseModel):
     current_temperature: Optional[int] = Field(..., alias="currentTemperature")
     set_temperature: int = Field(..., alias="setTemperature")
     flags: ZoneFlagsModel
-    zone_state: Literal["zoneOff", "noAlarm", "zoneUnregistered"] = Field(..., alias="zoneState")
+    zone_state: Literal["zoneOff", "zoneOn", "noAlarm", "zoneUnregistered", "sensorDamaged", "noCommunication"] = Field(..., alias="zoneState")
     signal_strength: Optional[int] = Field(..., alias="signalStrength")
     battery_level: Optional[int] = Field(..., alias="batteryLevel")
     actuators_open: int = Field(..., alias="actuatorsOpen")

--- a/tests/sample-data/module.json
+++ b/tests/sample-data/module.json
@@ -275,7 +275,7 @@
             "humidityAlgorytm": 0,
             "zoneExcluded": 0
           },
-          "zoneState": "noAlarm",
+          "zoneState": "zoneOn",
           "signalStrength": 53,
           "batteryLevel": 100,
           "actuatorsOpen": 0,
@@ -467,7 +467,7 @@
             "humidityAlgorytm": 0,
             "zoneExcluded": 0
           },
-          "zoneState": "noAlarm",
+          "zoneState": "sensorDamaged",
           "signalStrength": 31,
           "batteryLevel": 100,
           "actuatorsOpen": 0,
@@ -659,7 +659,7 @@
             "humidityAlgorytm": 0,
             "zoneExcluded": 0
           },
-          "zoneState": "noAlarm",
+          "zoneState": "noCommunication",
           "signalStrength": 13,
           "batteryLevel": 100,
           "actuatorsOpen": 0,

--- a/tests/sample-data/module.json
+++ b/tests/sample-data/module.json
@@ -275,7 +275,7 @@
             "humidityAlgorytm": 0,
             "zoneExcluded": 0
           },
-          "zoneState": "zoneOn",
+          "zoneState": "noAlarm",
           "signalStrength": 53,
           "batteryLevel": 100,
           "actuatorsOpen": 0,


### PR DESCRIPTION
Fixes https://github.com/jnsgruk/pytouchlinesl/issues/6 

I looked at the Roth dashboard code and found some additional states that can be returned.

EDIT: ~~Should the `sensorDamaged` and `noCommunication` states be considered as part of the `enabled` property?~~ Probably not when I think about it. The zone is still enabled even if it's in an alarm state.