### PR TITLE
feat(zone): expose `algorithm` property

### DIFF
--- a/pytouchlinesl/client/models/models.py
+++ b/pytouchlinesl/client/models/models.py
@@ -15,7 +15,7 @@ except ImportError:
 class ZoneFlagsModel(BaseModel):
     relay_state: str = Field(..., alias="relayState")
     min_one_window_open: bool = Field(..., alias="minOneWindowOpen")
-    algorithm: str
+    algorithm: Literal["heating", "cooling"]
     floor_sensor: int = Field(..., alias="floorSensor")
     humidity_algorytm: int = Field(..., alias="humidityAlgorytm")
     zone_excluded: int = Field(..., alias="zoneExcluded")

--- a/pytouchlinesl/zone.py
+++ b/pytouchlinesl/zone.py
@@ -117,6 +117,11 @@ class Zone:
         """Return whether or not the zone's relay is on."""
         return self._raw_data.zone.flags.relay_state == "on"
 
+    @property
+    def algorithm(self) -> Literal["heating", "cooling"]:
+        """Return the zone's current algorithm, either `heating` or `cooling`."""
+        return self._raw_data.zone.flags.algorithm
+
     async def set_temperature(self, temperature: float):
         """Set a constant target temperature for the zone."""
         await self._client.set_zone_temperature(

--- a/tests/sample-data/module.json
+++ b/tests/sample-data/module.json
@@ -462,7 +462,7 @@
           "flags": {
             "relayState": "off",
             "minOneWindowOpen": false,
-            "algorithm": "heating",
+            "algorithm": "cooling",
             "floorSensor": 0,
             "humidityAlgorytm": 0,
             "zoneExcluded": 0

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -7,6 +7,7 @@ test_attrs = [
     ("mode", "globalSchedule"),
     ("enabled", True),
     ("relay_on", True),
+    ("algorithm", "heating"),
 ]
 
 


### PR DESCRIPTION
I don't have cooling in my system, but since I'm planning to take a look at hvac mode in HASS I figured we may as well use the actual state of the zone.