### PR TITLE
feat(zone): expose `signal_strength` property and add `alarm` state

### DIFF
--- a/pytouchlinesl/zone.py
+++ b/pytouchlinesl/zone.py
@@ -122,6 +122,21 @@ class Zone:
         """Return the zone's current algorithm, either `heating` or `cooling`."""
         return self._raw_data.zone.flags.algorithm
 
+    @property
+    def signal_strength(self) -> int | None:
+        """Return the signal strength of the zone."""
+        return self._raw_data.zone.signal_strength
+
+    @property
+    def alarm(self) -> Literal["sensor_damaged", "no_communication"] | None:
+        """Return the alarm state of the zone."""
+        state = self._raw_data.zone.zone_state
+        if state == "sensorDamaged":
+            return "sensor_damaged"
+        elif state == "noCommunication":
+            return "no_communication"
+        return None
+
     async def set_temperature(self, temperature: float):
         """Set a constant target temperature for the zone."""
         await self._client.set_zone_temperature(

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -8,6 +8,8 @@ test_attrs = [
     ("enabled", True),
     ("relay_on", True),
     ("algorithm", "heating"),
+    ("signal_strength", 53),
+    ("alarm", None),
 ]
 
 


### PR DESCRIPTION
Exposes `signal_strength` and adds an `alarm` property that is set when the thermostat is out of range/battery, or damaged. This matches the alarm state in the Roth app.

I've prepared a Home Assistant PR that adds battery state, and the HVACAction state. With the sensor entity created it's trivial to add these two as sensors as well.
https://github.com/home-assistant/core/compare/dev...peroo:core:touchline-sensors