### PR TITLE
Fix data caching

### DIFF
--- a/pytouchlinesl/module.py
+++ b/pytouchlinesl/module.py
@@ -62,7 +62,7 @@ class Module:
         self._raw_data: ModuleModel
         # Unix timestamp representing the last time the _raw_data was fetched
         self._last_fetched = 0
-        self._cache_validity = cache_validity
+        self._cache_validity = cache_validity * 1000
 
         self._zones: list[Zone] = []
         self._schedules: list[GlobalScheduleModel] = []
@@ -96,13 +96,13 @@ class Module:
             include_off: (Optional) Include zones which are switched off in the results.
             refresh:     (Optional) Force the data to be refreshed using the API.
         """
-        if not self._zones or refresh:
-            data = await self._data(refresh=refresh)
+        data = await self._data(refresh=refresh)
 
-            for z in data.zones.elements:
-                schedule = await self.schedule_by_idx(z.mode.schedule_index)
-                zone = Zone(module=self, client=self._client, zone_data=z, schedule=schedule)
-                self._zones.append(zone)
+        self._zones = []
+        for z in data.zones.elements:
+            schedule = await self.schedule_by_idx(z.mode.schedule_index)
+            zone = Zone(module=self, client=self._client, zone_data=z, schedule=schedule)
+            self._zones.append(zone)
 
         if include_off:
             return self._zones
@@ -136,9 +136,8 @@ class Module:
         Args:
             refresh: (Optional) Force the data to be refreshed using the API.
         """
-        if not self._schedules or refresh:
-            data = await self._data(refresh=refresh)
-            self._schedules = data.zones.global_schedules.elements
+        data = await self._data(refresh=refresh)
+        self._schedules = data.zones.global_schedules.elements
 
         return self._schedules
 

--- a/pytouchlinesl/touchlinesl.py
+++ b/pytouchlinesl/touchlinesl.py
@@ -31,13 +31,15 @@ class TouchlineSL:
         username: str | None = None,
         password: str | None = None,
         client: BaseClient | None = None,
+        cache_validity: int = 30,
     ):
         """Construct the instance with either credentials or an authenticated client.
 
         Args:
-            username: (Optional) Username for TouchlineSL account. Ignored if client is passed.
-            password: (Optional) Password for TouchlineSL account. Ignored if client is passed.
-            client:   (Optional) An instance of a RothAPI class.
+            username:       (Optional) Username for TouchlineSL account. Ignored if client is passed.
+            password:       (Optional) Password for TouchlineSL account. Ignored if client is passed.
+            client:         (Optional) An instance of a RothAPI class.
+            cache_validity: (Optional) The number of seconds for which module data should be cached.
         """
         self._modules: list[Module] = []
 
@@ -52,6 +54,8 @@ class TouchlineSL:
                 raise TypeError("username and password must be strings if no client is provided")
             self._client = RothAPI(username=username, password=password)
 
+        self._cache_validity = cache_validity
+
     async def user_id(self) -> int:
         """Return the unique user ID of the authenticated account."""
         return await self._client.user_id()
@@ -64,7 +68,10 @@ class TouchlineSL:
         """
         if not self._modules or refresh:
             data = await self._client.modules()
-            self._modules = [Module(client=self._client, module_data=m) for m in data]
+            self._modules = [
+                Module(client=self._client, module_data=m, cache_validity=self._cache_validity)
+                for m in data
+            ]
 
         return self._modules
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,8 +12,21 @@ def test_touchlinesl() -> TouchlineSL:
 
 
 @pytest.fixture
+def test_touchlinesl_short_cache() -> TouchlineSL:
+    client = FakeRothAPI()
+    return TouchlineSL(client=client, cache_validity=0.1)
+
+
+@pytest.fixture
 async def test_module(test_touchlinesl: TouchlineSL) -> Module:
     m = await test_touchlinesl.module(module_id="1234a5678a9123a456a7891234a56789")
+    assert isinstance(m, Module)
+    return m
+
+
+@pytest.fixture
+async def test_module_short_cache(test_touchlinesl_short_cache: TouchlineSL) -> Module:
+    m = await test_touchlinesl_short_cache.module(module_id="1234a5678a9123a456a7891234a56789")
     assert isinstance(m, Module)
     return m
 

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -46,6 +46,16 @@ async def test_zones_cache(test_module):
 
 
 @pytest.mark.asyncio
+async def test_zones_cache_expired(test_module_short_cache):
+    await test_module_short_cache.zones()
+    initial_fetch_time = test_module_short_cache._last_fetched
+    await asyncio.sleep(0.25)
+
+    await test_module_short_cache.zones()
+    assert initial_fetch_time != test_module_short_cache._last_fetched
+
+
+@pytest.mark.asyncio
 async def test_zones_force_refresh(test_module):
     await test_module.zones()
     initial_fetch_time = test_module._last_fetched
@@ -117,6 +127,16 @@ async def test_schedules_cache(test_module):
 
     await test_module.schedules()
     assert initial_fetch_time == test_module._last_fetched
+
+
+@pytest.mark.asyncio
+async def test_schedules_cache_expired(test_module_short_cache):
+    await test_module_short_cache.schedules()
+    initial_fetch_time = test_module_short_cache._last_fetched
+    await asyncio.sleep(0.5)
+
+    await test_module_short_cache.schedules()
+    assert initial_fetch_time != test_module_short_cache._last_fetched
 
 
 @pytest.mark.asyncio

--- a/tests/test_touchlinesl.py
+++ b/tests/test_touchlinesl.py
@@ -40,6 +40,15 @@ async def test_modules(test_touchlinesl: TouchlineSL):
     modules = await test_touchlinesl.modules()
     for m in modules:
         assert isinstance(m, Module)
+        assert m._cache_validity == 30000
+
+
+@pytest.mark.asyncio
+async def test_modules_short_cache(test_touchlinesl_short_cache: TouchlineSL):
+    modules = await test_touchlinesl_short_cache.modules()
+    for m in modules:
+        assert isinstance(m, Module)
+        assert m._cache_validity == 100
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
When looking at my Home Assistant dashboard I realized that data is never actually refreshed, except when HASS is restarted.

I noticed two bugs:
* The default cache validity is 30ms rather than 30s.
* Data is never refreshed because the `zones` and `schedules` functions only fetch new data when explicitly requested, which the HASS integration does not. Basically this means there's no way to use the internal caching since you have to always force refresh. I've removed the refresh checks so the caching is solely handled by `_data`, which ensures it always respects `cache_validity`.

Some tests would be nice, but I'm not at all familiar with python testing.