### PR TITLE
Fix error because of missing description in tiles

### DIFF
--- a/pytouchlinesl/client/client.py
+++ b/pytouchlinesl/client/client.py
@@ -104,11 +104,7 @@ class RothAPI(BaseClient):
 
         resp = await self._authed_get(f"/users/{self._user_id}/modules/{module_id}")
         
-        """Because of a later check in pydantic a description is required. the Tiles don't always have a description. this adds an empty description when there is none in the tiles."""
-        if "tiles" in resp:
-            for tile in resp["tiles"]:
-                if "params" in tile and "description" not in tile["params"]:
-                    tile["params"]["description"] = ""
+      
 
         return ModuleModel(**resp)
 

--- a/pytouchlinesl/client/client.py
+++ b/pytouchlinesl/client/client.py
@@ -103,6 +103,13 @@ class RothAPI(BaseClient):
             await self._login()
 
         resp = await self._authed_get(f"/users/{self._user_id}/modules/{module_id}")
+        
+        """Because of a later check in pydantic a description is required. the Tiles don't always have a description. this adds an empty description when there is none in the tiles."""
+        if "tiles" in resp:
+            for tile in resp["tiles"]:
+                if "params" in tile and "description" not in tile["params"]:
+                    tile["params"]["description"] = ""
+
         return ModuleModel(**resp)
 
     async def set_zone_temperature(

--- a/pytouchlinesl/client/models/models.py
+++ b/pytouchlinesl/client/models/models.py
@@ -126,7 +126,7 @@ class ZonesModel(BaseModel):
 
 
 class ParamsModel(BaseModel):
-    description: Optional[str]
+    description: Optional[str] = None
     working_status: Optional[bool] = Field(None, alias="workingStatus")
     txt_id: Optional[int] = Field(None, alias="txtId")
     icon_id: Optional[int] = Field(None, alias="iconId")


### PR DESCRIPTION
Found that the root cause of the [Roth Touchline SL #150472](https://github.com/home-assistant/core/issues/150472) issue, is that the "Tiles" returned by the API doesn't always contain a description. The pydantic validator requires a description and fails because these don't exist. 

The proposed fix here is to add an empty description into the "Tiles", thereby bypassing the problem.
