### PR TITLE
Better bug fix for missing description on tiles

### DIFF
--- a/pytouchlinesl/client/client.py
+++ b/pytouchlinesl/client/client.py
@@ -103,8 +103,6 @@ class RothAPI(BaseClient):
             await self._login()
 
         resp = await self._authed_get(f"/users/{self._user_id}/modules/{module_id}")
-        
-      
 
         return ModuleModel(**resp)
 

--- a/pytouchlinesl/client/client.py
+++ b/pytouchlinesl/client/client.py
@@ -104,11 +104,7 @@ class RothAPI(BaseClient):
 
         resp = await self._authed_get(f"/users/{self._user_id}/modules/{module_id}")
         
-        """Because of a later check in pydantic a description is required. the Tiles don't always have a description. this adds an empty description when there is none in the tiles."""
-        if "tiles" in resp:
-            for tile in resp["tiles"]:
-                if "params" in tile and "description" not in tile["params"]:
-                    tile["params"]["description"] = ""
+      
 
         return ModuleModel(**resp)
 

--- a/pytouchlinesl/client/client.py
+++ b/pytouchlinesl/client/client.py
@@ -103,6 +103,13 @@ class RothAPI(BaseClient):
             await self._login()
 
         resp = await self._authed_get(f"/users/{self._user_id}/modules/{module_id}")
+        
+        """Because of a later check in pydantic a description is required. the Tiles don't always have a description. this adds an empty description when there is none in the tiles."""
+        if "tiles" in resp:
+            for tile in resp["tiles"]:
+                if "params" in tile and "description" not in tile["params"]:
+                    tile["params"]["description"] = ""
+
         return ModuleModel(**resp)
 
     async def set_zone_temperature(

--- a/pytouchlinesl/client/models/models.py
+++ b/pytouchlinesl/client/models/models.py
@@ -126,7 +126,7 @@ class ZonesModel(BaseModel):
 
 
 class ParamsModel(BaseModel):
-    description: Optional[str]
+    description: Optional[str] = None
     working_status: Optional[bool] = Field(None, alias="workingStatus")
     txt_id: Optional[int] = Field(None, alias="txtId")
     icon_id: Optional[int] = Field(None, alias="iconId")


### PR DESCRIPTION
The bug is that the pydantic validation wants a description for the tiles, but most of them don't have a description. 
found a solution which was to add a description to the ones that missed one, but that was a bypass. so this pull request fixes the problem and makes the description truly optional in the model instead.

This pull request makes minor improvements to the codebase, focusing on better default handling for optional fields and minor formatting adjustments.

*Model improvements:*

* Set a default value of `None` for the `description` field in the `ParamsModel` class in `models.py`, ensuring that missing descriptions are handled gracefully.


this should fix the problem in this issue: [Fix error because of missing description in tiles jnsgruk/pytouchlinesl#16](https://github.com/jnsgruk/pytouchlinesl/pull/16)
