### PR TITLE
style: format README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ import os
 
 from pytouchlinesl import TouchlineSL
 
+
 async def touchlinesl_example():
     tsl = TouchlineSL(
         username=os.getenv("TOUCHLINESL_LOGIN"),
@@ -66,6 +67,7 @@ async def touchlinesl_example():
     kitchen = await module.zone(2411)
     living_spaces = await module.schedule_by_name("Living Spaces")
     await kitchen.set_schedule(living_spaces.id)
+
 
 if __name__ == "__main__":
     asyncio.set_event_loop(asyncio.new_event_loop())


### PR DESCRIPTION
## Summary

- formats the Python example in `README.md` for Ruff 0.16
- fixes the formatting check failing on #34

## Verification

- `uv run ruff check`
- `uv run ruff format --check`
- `uv run --python 3.10 pytest -q` — 49 passed
- `uv run --python 3.11 pytest -q` — 49 passed
- `uv run --python 3.12 pytest -q` — 49 passed
